### PR TITLE
[doc] Use the full path of the image so it shows up on `npm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ API to the platform has to offer.
   allows you to mount and render components in your test suite.
 
 <p align="center">
-  <img width="800" height="607" src="./docs/ekke-react-native-intro.gif" />
+  <img width="800" height="607" src="https://raw.githubusercontent.com/godaddy/ekke/master/docs/ekke-react-native-intro.gif" />
   <br />
   <sub>Ekke in action: running a test suite, streaming results back to the CLI</sub>
 </p>


### PR DESCRIPTION
As per title, it seems that [npm](https://www.npmjs.com/package/ekke) is incapable of resolving relative paths in a README file to the full path when the image is added using HTML.

Using the full path should allow the image to show up again on npm's packages page.