### PR TITLE
[doc] Enable CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+#
+# Default:
+#
+# These users will be automatically assigned as reviewer for everything in the
+# repository unless a different match is made.
+#
+* @3rd-Eden @swaagie


### PR DESCRIPTION
As per title, enable the CODEOWNERS feature of GitHub to automatically assign users to pull requests. 