### PR TITLE
[ci] Run against latest LTS of Node.js, configure Greenkeeper and ignore CI files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      - image: circleci/node:10.15.3
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/.npmignore
+++ b/.npmignore
@@ -70,6 +70,8 @@ android
 
 # Above this line should be a copy of our .gitignore
 # Additional files that need to be ignore before publish
+.github
+.circleci
 test*
 docs
 examples

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ekke",
-  "version": "0.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,14 @@
       "configFile": "./test/.babelrc"
     }
   },
+  "greenkeeper": {
+    "commitMessages": {
+      "dependencyUpdate": "[deps] Update ${dependency} to version ${version}",
+      "devDependencyUpdate": "[deps|dev] Update ${dependency} to version ${version}",
+      "dependencyPin": "[deps] Pin ${dependency} to ${oldVersion}",
+      "devDependencyPin": "[deps|dev] Fix: Pin ${dependency} to ${oldVersion}"
+    }
+  },
   "dependencies": {
     "argh": "^1.0.0",
     "babel-plugin-rewrite-require": "^1.14.5",

--- a/test/ekke/evaluator.test.js
+++ b/test/ekke/evaluator.test.js
@@ -18,6 +18,8 @@ describe('(ekke) Evaluator', function () {
   beforeEach(create);
 
   describe('bundle interactions:', function () {
+    this.timeout(5000);
+
     let bundle;
 
     before(async function () {

--- a/test/ekke/subway.test.js
+++ b/test/ekke/subway.test.js
@@ -113,6 +113,8 @@ describe('(ekke) Subway', function () {
 
   describe('#request', function () {
     it('makes a HTTP request', async function () {
+      this.timeout(5000);
+
       const resp = await sub.request({
         url: 'https://google.com',
         method: 'GET'


### PR DESCRIPTION
This PR contains a clean up of our CI.

- It ensures that our tests are ran against the latest LTS version of Node
- Customized the Greenkeeper commit messages so they match our commit format
- Ignored additional files
- Increased timeout on Android.