### PR TITLE
Use a custom path for the Metro cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ You can use the following CLI flags to change the behavior of the command:
   alive.
   **Defaults to false.**
 - `--reset-cache` The Metro Bundler caching system is enabled by default so
-  that tests run in a performant way and don't alway rebuild. Using this
+  that tests run in a performant way and don't always rebuild. Using this
   flag will disable the cache.
   **Defaults to false.**
 - `--cache-location` We already made sure that the Metro Bundler cache of your

--- a/README.md
+++ b/README.md
@@ -381,10 +381,14 @@ You can use the following CLI flags to change the behavior of the command:
   the process to exit, you can use the `--watch` flag to keep the CLI process
   alive.
   **Defaults to false.**
-- `--no-reset-cache` The Metro Bundler caching system is disabled by default so
-  your tests, and require statements are always freshly compiled. Using this
-  flag will re-enable the cache.
+- `--reset-cache` The Metro Bundler caching system is enabled by default so
+  that tests run in a performant way and don't alway rebuild. Using this
+  flag will disable the cache.
   **Defaults to false.**
+- `--cache-location` We already made sure that the Metro Bundler cache of your
+  test doesn't collide with your test cache, but if you like to store it
+  somewhere else you can change it with this flag.
+  **Defaults to `os.tempdir()/ekke-cache`.**
 - `--no-silent` We silence the output of the Metro bundler by default, this
   allows you to see the Metro bundler output again.
   **Defaults to false.**
@@ -415,7 +419,7 @@ command:
 
 ```
 
-ekke (v0.0.0)
+ekke (v1.0.2)
 Ekke-Ekke-Ekke-Ekke-PTANG. Zoo-Boing. Z' nourrwringmm...
 
 COMMANDS:
@@ -427,8 +431,9 @@ run      Run the given glob of test files.
          --watch          Don't exit when the tests complete but keep listening.
          --no-silent      Do not suppress the output of Metro.
          --require        Require module (before tests are executed).
-         --no-reset-cache Do not clear the Metro cache.
-help     Displays this help message.
+         --reset-cache    Clear the Metro cache.
+         --cache-location Change the Metro cache location.
+help             Displays this help message.
          --no-color       Disable colors in help message.
 
 EXAMPLES:

--- a/api/commands/help.js
+++ b/api/commands/help.js
@@ -24,8 +24,9 @@ ${'run'}|>#00A63F      Run the given glob of test files.
          ${'--watch'}|>dimgray          Don't exit when the tests complete but keep listening.
          ${'--no-silent'}|>dimgray      Do not suppress the output of Metro.
          ${'--require'}|>dimgray        Require module (before tests are executed).
-         ${'--no-reset-cache'}|>dimgray Do not clear the Metro cache.
-${'help'}|>#00A63F     Displays this help message.
+         ${'--reset-cache'}|>dimgray    Clear the Metro cache.
+         ${'--cache-location'}|>dimgray Change the Metro cache location.
+${'help'}|>#00A63F             Displays this help message.
          ${'--no-color'}|>dimgray       Disable colors in help message.
 
 EXAMPLES:

--- a/api/index.js
+++ b/api/index.js
@@ -120,7 +120,7 @@ Ekke.defaults = {
   'hostname': 'localhost',    // Hostname we should create our server upon
   'port': 1975,               // The port number of the created server
   'silent': true,             // Silence Metro bundler
-  'reset-cache': true         // The cache key poorly handled, so turn off by default.
+  'reset-cache': false        // The cache key poorly handled, so turn off by default.
 };
 
 //

--- a/api/index.js
+++ b/api/index.js
@@ -1,6 +1,8 @@
 const EventEmitter = require('eventemitter3');
 const diagnostics = require('diagnostics');
 const cli = require('argh').argv;
+const os = require('os');
+const path = require('path');
 
 /**
  * A basic API, and CLI interface for Ekke. The only difference between
@@ -117,10 +119,11 @@ Ekke.commands = {
  * @public
  */
 Ekke.defaults = {
-  'hostname': 'localhost',    // Hostname we should create our server upon
-  'port': 1975,               // The port number of the created server
-  'silent': true,             // Silence Metro bundler
-  'reset-cache': false        // The cache key poorly handled, so turn off by default.
+  'hostname': 'localhost',                                 // Hostname we should create our server upon
+  'port': 1975,                                            // The port number of the created server
+  'silent': true,                                          // Silence Metro bundler
+  'reset-cache': false,                                    // Turn off the Metro bundler cache
+  'cache-location': path.join(os.tmpdir(), 'ekke-cache')   // Metro bundler cacheStores location
 };
 
 //

--- a/api/metro/configure.js
+++ b/api/metro/configure.js
@@ -1,7 +1,9 @@
 const { mergeConfig, loadConfig } = require('metro-config');
+const { FileStore } = require('metro-cache');
 const resolve = require('metro-resolver').resolve;
 const diagnostics = require('diagnostics');
 const source = require('./source');
+const os = require('os');
 const path = require('path');
 
 //
@@ -18,12 +20,18 @@ const debug = diagnostics('ekke:configure');
  * @public
  */
 async function configure(flags) {
+  const cacheStoreLocation = flags['cache-location'] || path.join(os.tmpdir(), 'ekke-cache');
   const reactNativePath = path.dirname(require.resolve('react-native/package.json'));
   const config = await loadConfig();
   const custom = {
     resolver: {},
     serializer: {},
-    transformer: {}
+    transformer: {},
+    cacheStores: [
+      new FileStore({
+        root: cacheStoreLocation
+      })
+    ]
   };
 
   //

--- a/api/metro/configure.js
+++ b/api/metro/configure.js
@@ -3,7 +3,6 @@ const { FileStore } = require('metro-cache');
 const resolve = require('metro-resolver').resolve;
 const diagnostics = require('diagnostics');
 const source = require('./source');
-const os = require('os');
 const path = require('path');
 
 //
@@ -20,7 +19,6 @@ const debug = diagnostics('ekke:configure');
  * @public
  */
 async function configure(flags) {
-  const cacheStoreLocation = flags['cache-location'] || path.join(os.tmpdir(), 'ekke-cache');
   const reactNativePath = path.dirname(require.resolve('react-native/package.json'));
   const config = await loadConfig();
   const custom = {
@@ -29,7 +27,7 @@ async function configure(flags) {
     transformer: {},
     cacheStores: [
       new FileStore({
-        root: cacheStoreLocation
+        root: flags['cache-location']
       })
     ]
   };


### PR DESCRIPTION
Fixes: https://github.com/godaddy/ekke/issues/11

This sets a custom cacheStore for Metro and allows the user to control it using the `--cache-location` flag. By default it will use [the same location as Metro](https://github.com/facebook/metro/blob/3bf0a9354633f16555cbf4cb8dcc0e8f13c1a323/packages/metro-config/src/defaults/index.js#L114) except for the last folder, which specifies the `ekke-cache` to keep them separate from each other.

**Sidenote**
The documentation mentioned a `--no-reset-cache` flag, but I couldn't find any code related to it, so I'm assuming it was not actually working. That's why I inverted the documentation to reflect the actual new behaviour.

**Acceptance Criteria**
 - [x] Configure a custom Metro File Cache in our custom configuration.
 - [x] Configure the new Metro cache to a different, customizable location.
 - [x] Verify that when we run ekke we do not clear the cache of our host application.
 - [x] The new configuration is documented and has unit tests.