### PR TITLE
Support Windows Paths

### DIFF
--- a/api/metro/source.js
+++ b/api/metro/source.js
@@ -36,6 +36,7 @@ async function source({ globs = [], fake, runner = 'mocha' }) {
   //
   const requires = files
     .map(file => path.join(fake, file))
+    .map(file => file.replace(/\\/g, '\\\\'))
     .map(file => `require("${file}");`)
     .join('\n');
 


### PR DESCRIPTION
When running ekke from Windows, the source generated from the template file contains invalid require paths due to unescaped backslashes.

The following error is produced when the ekke cli attempts to create the test bundle on Windows:
```
error: bundling failed: Error: Unable to resolve module `ekke-ekke-ekke-ekkeSamplesekke estsexample.mocha.js` from `C:\projects\xxxxx\node_modules\ekke\api\tmp\1036ebee65e879343047194fba31798cdee8d503f5772c4d7943ef2ffa284961.js`: Module `ekke-ekke-ekke-ekkeSamplesekke       estsexample.mocha.js` does not exist in the Haste module map
```

The generated exports in `ekke/api/tmp/1036ebee65e879343047194fba31798cdee8d503f5772c4d7943ef2ffa284961.js`:
```
module.exports = {
  runner: require('mocha'),
  suites: function suites() {
    require("ekke-ekke-ekke-ekke\Samples\ekke\tests\example.mocha.js");
  }
}
```

With this patch, the exports in the template file are correctly generated as:
```
module.exports = {
  runner: require('mocha'),
  suites: function suites() {
    require("ekke-ekke-ekke-ekke\\Samples\\ekke\\tests\\example.mocha.js");
  }
}
```